### PR TITLE
Update gift-membership-received.md

### DIFF
--- a/streamerbot/3.api/2.triggers/youtube/membership/gift-membership-received.md
+++ b/streamerbot/3.api/2.triggers/youtube/membership/gift-membership-received.md
@@ -6,7 +6,9 @@ Name | Description
 ----:|:------------
 `id` | The id of the membership gifting event
 `tier` | The tier the gifted user received
-`gifterUser` | The display name of the user who received the gifted membership
-`gifterUserName` | The user name of the user who received the gifted membership
-`gifterUserId` | The id of the user who received the gifted membership
-`gifterUserType` | The type of user who received the gifted membership
+`gifterUser` | The display name of the user who gave the gifted membership
+`gifterUserName` | The user name of the user who gave the gifted membership
+`gifterUserId` | The id of the user who gave the gifted membership
+`gifterUserType` | The type of user who gave the gifted membership
+`user` | The user name of the user who received the gifted membership
+`userId` | The id of the user who received the gifted membership


### PR DESCRIPTION
The docs for the gifter and receiver were opposite. The `gifter` is the person who purchased/gave the gifted membership. I also think it might be helpful to add the `user` and `userId` variables to be clear that those variables can be used for the user and ID of the receiver of the gifted membership.