### PR TITLE
Update 11.csharp.md

### DIFF
--- a/streamerbot/2.guide/11.csharp.md
+++ b/streamerbot/2.guide/11.csharp.md
@@ -35,7 +35,7 @@ Explore all available C# methods at [API References > C# Methods](/api/csharp)
 
 
 ## Arguments
-All C# actions have access to a Dictionary, `args`, containing the current argument stack.
+All C# actions have access to a Dictionary<string, object>, `args`, containing the current argument stack.
 
 ::callout{icon=i-mdi-lightbulb color=amber}
 In the event that the `args` Dictionary does not contain your key, a `KeyNotFound` exception will be thrown.
@@ -44,40 +44,34 @@ In the event that the `args` Dictionary does not contain your key, a `KeyNotFoun
 ::
 
 ::code-group
+  ```cs [TryGetValue]
+  // If %rawInput% exists, store it in rawInput
+  if (!args.TryGetValue("rawInput", out object rawInputObj))
+    return false; // Arg doesn't exist, stop execution
+  string rawInput = rawInputObj?.ToString();
+
+  // Do something with rawInput...
+  ```
   ```cs [CPH TryGetArg]
   string rawInput;
   // If %rawInput% exists, store it in rawInput
   if (!CPH.TryGetArg<string>("rawInput", out rawInput))
-  {
-    // Arg doesn't exist, stop execution
-    return false;
-  }
-
-  // Do something with rawInput...
-  ```
-  ```cs [TryGetValue]
-  // If %rawInput% exists, store it in rawInput
-  if (!args.TryGetValue("rawInput", out var rawInputObj))
-  {
-    // Arg doesn't exist, stop execution
-    return false;
-  }
-  string rawInput = rawInputObj?.ToString();
+    return false; // Arg doesn't exist, stop execution
 
   // Do something with rawInput...
   ```
 ::
 
 ::callout{icon=i-mdi-lightbulb color=amber}
-Special arguments `__source` and `eventType` must be accessed with their corresponding methods:
+Special arguments `eventSource` and `__source` must be accessed with their corresponding methods:
 ::
 
 ::code-group
   ```cs [CPH GetSource]
-  EventSource source = CPH.GetSource();
+  EventSource source = CPH.GetSource(); // eventSource in args
   ```
   ```cs [CPH GetEventType]
-  EventType type = CPH.GetEventType();
+  EventType type = CPH.GetEventType(); // __source in args
   ```
 ::
 


### PR DESCRIPTION
Moved TryGetValue to the forefront until v0.2.3 is released

Made a correction to EventSource CPH.GetSource() getting for eventSource, not eventType