### PR TITLE
Update YouTubeBroadcaster.md

### DIFF
--- a/streamerbot/3.api/_variables/YouTubeBroadcaster.md
+++ b/streamerbot/3.api/_variables/YouTubeBroadcaster.md
@@ -17,5 +17,5 @@ variables:
   - name: broadcastId
     type: string
     description: The broadcast ID from the livestream
-    value: UCI9-KG2xoyh5z-g41IL2jqf
+    value: UCI9-KG2xoy
 ---


### PR DESCRIPTION
Changed `broadcastId` to 11 digits to avoid confusion between Video ID and Broadcast ID since it is the same thing.