### PR TITLE
Barkermn01 twitch variables wrong case

### DIFF
--- a/streamerbot/3.api/_variables/TwitchChat.md
+++ b/streamerbot/3.api/_variables/TwitchChat.md
@@ -50,23 +50,19 @@ variables:
     type: List<Twitch.Common.Models.Emote>
     description: A C# accessible list of emotes used in the chat message
     variables:
-      - name: id
-        type: number
-        description: The id of the emote
-        value: 25
-      - name: type
+      - name: Type
         type: string
         description: From which source the emote came from
         value: Twitch
-      - name: startIndex
+      - name: StartIndex
         type: number
         description: On which letter the emote started
         value: 0
-      - name: endIndex
+      - name: EndIndex
         type: number
         description: On which letter the emote ended
         value: 4
-      - name: imageUrl
+      - name: ImageUrl
         type: string
         description: The URL of an image from the emote
         value: https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/2.0

--- a/streamerbot/3.api/_variables/TwitchUser.md
+++ b/streamerbot/3.api/_variables/TwitchUser.md
@@ -42,15 +42,15 @@ variables:
     type: List<Twitch.Common.Models.Badge>
     description: A C# accessible list of emotes used in the chat message
     variables:
-      - name: name
+      - name: Name
         type: string
         description: The name of the badge
         value: moderator
-      - name: version
+      - name: Version
         type: number
         description: The version of the badge
         value: 1
-      - name: imageUrl
+      - name: ImageUrl
         type: string
         description: The image URL of the badge
         value: https://static-cdn.jtvnw.net/badges/v1/3267646d-33f0-4b17-b3df-f923a41db1d0/3


### PR DESCRIPTION
There was an `id` variable defined against the Twitch Emote object that was not provided, there was also incorrect cases on both TwitchChat variables and TwitchUser variables.