### PR TITLE
Update send-message-to-channel.md to show C# method usage

### DIFF
--- a/streamerbot/3.api/1.sub-actions/trovo/chat/send-message-to-channel.md
+++ b/streamerbot/3.api/1.sub-actions/trovo/chat/send-message-to-channel.md
@@ -11,4 +11,4 @@ Select the Twitch account to use when sending the message:
 Enter the text you would like to send
 
 ## C# Usage
-:csharp-method
+:csharp-method{name=SendTrovoMessage}


### PR DESCRIPTION
Added missing method name to Trovo's send-message-to-channel.md so the sub-actions documentation can show the C# method usage correctly