### PR TITLE
Update gift-membership-received.md

### DIFF
--- a/streamerbot/3.api/2.triggers/youtube/membership/gift-membership-received.md
+++ b/streamerbot/3.api/2.triggers/youtube/membership/gift-membership-received.md
@@ -6,7 +6,7 @@ variables:
     type: string
     description: The id of the membership gifting event
   - name: tier
-    type: number
+    type: string
     description: The tier the gifted user received
   - name: gifterUser
     type: string


### PR DESCRIPTION
Tier was showing as `number` instead of `string` for the type