### PR TITLE
Fix: change commandId type from string to Guid + Fix: typos

### DIFF
--- a/streamerbot/3.api/2.triggers/core/commands/command-cooldown.md
+++ b/streamerbot/3.api/2.triggers/core/commands/command-cooldown.md
@@ -7,7 +7,7 @@ variables:
     description: The command that was used
     value: '!shoutout'
   - name: commandId
-    type: string
+    type: Guid
     description: The id of the command
   - name: commandSource
     type: string

--- a/streamerbot/3.api/2.triggers/core/commands/command-triggered.md
+++ b/streamerbot/3.api/2.triggers/core/commands/command-triggered.md
@@ -7,7 +7,7 @@ variables:
     description: The command that was used
     value: '!shoutout'
   - name: commandId
-    type: string
+    type: Guid
     description: The ID of the command
   - name: commandSource
     type: string

--- a/streamerbot/4.changelogs/.archive/Version-014.md
+++ b/streamerbot/4.changelogs/.archive/Version-014.md
@@ -222,7 +222,7 @@ One other thing to note, the `%rawInput%` variable for commands, specificially t
 ![commands-regex-01.png](/commands-regex-01.png)
 
 ### Command C# Methods
-Two new C# methods were added to be able to enable/disable a command.  Unlike other methods that only need a title, this requires the ID of the command, this can be retreived by right clicking on a command and selecting `Copy Command Id`
+Two new C# methods were added to be able to enable/disable a command.  Unlike other methods that only need a title, this requires the ID of the command, this can be retrieved by right clicking on a command and selecting `Copy Command Id`
 
 ```csharp
 void EnableCommand(string id);

--- a/streamerbot/4.changelogs/.archive/Version-015.md
+++ b/streamerbot/4.changelogs/.archive/Version-015.md
@@ -385,7 +385,7 @@ int ObsGetConnectionByName(string name);
 ```
 
 ### Command Cooldown Methods
-> The ID can be retreived by right clicking a command, and clicking the Copy Command ID option
+> The ID can be retrieved by right clicking a command, and clicking the Copy Command ID option
 {.is-info}
 
 ```csharp


### PR DESCRIPTION
I didn't change the commandId type elsewhere, only in these 2 places, because I don't know if it should stay a string in other places.