### PR TITLE
Remove "role" argument from Command Triggered trigger

### DIFF
--- a/streamerbot/3.api/2.triggers/core/commands/command-triggered.md
+++ b/streamerbot/3.api/2.triggers/core/commands/command-triggered.md
@@ -41,9 +41,6 @@ variables:
   - name: inputUrlEncoded#
     type: string
     description: The indexed word URL encoded
-  - name: role
-    type: number
-    description: What role the user has<br>1=`Viewer`, 2=`VIP`, 3=`Mod`, 4=`Broadcaster`
   - name: counter
     type: number
     description: A running total of how many times a command has been run since application launch

--- a/streamerbot/3.api/2.triggers/obs/event.md
+++ b/streamerbot/3.api/2.triggers/obs/event.md
@@ -20,12 +20,39 @@ variables:
     type: string
     description: The IP Address of the OBS connection
     value: 127.0.0.1
+  - name: obsEvent.*
+    type: string
+    description: The properties of the OBS event, as flattened JSON keys.
 ---
 
-::tip
-The variables populated by this trigger are different depending on the `Event` parameter
-::
-
-::bookmark{to="https://github.com/obsproject/obs-websocket/blob/master/docs/generated/protocol.md#events"}
+::read-more{to="https://github.com/obsproject/obs-websocket/blob/master/docs/generated/protocol.md#events"}
 Explore all supported [OBS Studio Events](https://github.com/obsproject/obs-websocket/blob/master/docs/generated/protocol.md#events) on their WebSocket protocol documentation
 ::
+
+::tip
+The variables populated by this trigger are different depending on the `Event` parameter.
+::
+
+For example, given the following event data from OBS:
+
+```json [example.json]
+{
+  event: "SceneListChanged",
+  scenes: [
+    {
+      sceneIndex: 0,
+      sceneName: "Be Right Back",
+      sceneUuid: "1234-5678-9abcd"
+    }
+  ]
+}
+```
+
+The following variables will be populated:
+
+| Name | Type | Value |
+| ---- | ---- | ----- |
+| `obsEvent.event`{lang=cs} | `string` | `"SceneListChanged"`{lang=cs} |
+| `obsEvent.scenes[0].sceneIndex`{lang=cs} | `int` | `0`{lang=cs} |
+| `obsEvent.scenes[0].sceneName`{lang=cs} | `string` | `"Be Right Back"`{lang=cs} |
+| `obsEvent.scenes[0].sceneUuid`{lang=cs} | `string` | `"1234-5678-9abcd"`{lang=cs} |


### PR DESCRIPTION
SB 0.2.4 does not appear to populate a "role" argument for either Twitch or Youtube command.