### PR TITLE
Add Twitch Broadcaster Information type mismatch

### DIFF
--- a/streamerbot/3.api/1.sub-actions/twitch/user/add-broadcaster-information.md
+++ b/streamerbot/3.api/1.sub-actions/twitch/user/add-broadcaster-information.md
@@ -16,5 +16,5 @@ variables:
     type: boolean
   - name: broadcastIsPartner
     description: Boolean value indicating if the broadcaster account is a Twitch partner
-    type: string
+    type: boolean
 ---


### PR DESCRIPTION
Changed the variable type of the `broadcastIsPartner` argument from `string` to `boolean`. As originally reported by [Ender Onryo on Discord](https://discord.com/channels/834650675224248362/1350513678432342036/1350513678432342036)