### PR TITLE
Twitch AutoMod Terms doc fix

### DIFF
--- a/streamerbot/3.api/2.triggers/twitch/moderation/blocked-terms-added.md
+++ b/streamerbot/3.api/2.triggers/twitch/moderation/blocked-terms-added.md
@@ -7,15 +7,15 @@ variables:
     type: datetime
     description: datetime of the addition
     value: 28.06.2024 20:13:20
-  - name: moderator.userName
+  - name: moderatorUsername
     type: string
     description: display name of the moderator who added the term
     value: Lyfesaver74
-  - name: moderator.login
+  - name: moderatorDisplayName
     type: string
     description: login name of the moderator who added the term
     value: lyfesaver74
-  - name: moderator.id
+  - name: moderatorId
     type: string
     description: display name of the moderator who added the term
     value: 161545467

--- a/streamerbot/3.api/2.triggers/twitch/moderation/blocked-terms-deleted.md
+++ b/streamerbot/3.api/2.triggers/twitch/moderation/blocked-terms-deleted.md
@@ -7,15 +7,15 @@ variables:
     type: datetime
     description: datetime of the deletion
     value: 28.06.2024 20:13:20
-  - name: moderator.userName
+  - name: moderatorUsername
     type: string
     description: display name of the moderator who deleted the term
     value: Lyfesaver74
-  - name: moderator.login
+  - name: moderatorDisplayName
     type: string
     description: login name of the moderator who deleted the term
     value: lyfesaver74
-  - name: moderator.id
+  - name: moderatorId
     type: string
     description: display name of the moderator who deleted the term
     value: 161545467

--- a/streamerbot/3.api/2.triggers/twitch/moderation/permitted-terms-added.md
+++ b/streamerbot/3.api/2.triggers/twitch/moderation/permitted-terms-added.md
@@ -7,15 +7,15 @@ variables:
     type: datetime
     description: datetime of the addition
     value: 28.06.2024 20:13:20
-  - name: moderator.userName
+  - name: moderatorUsername
     type: string
     description: display name of the moderator who added the term
     value: Lyfesaver74
-  - name: moderator.login
+  - name: moderatorDisplayName
     type: string
     description: login name of the moderator who added the term
     value: lyfesaver74
-  - name: moderator.id
+  - name: moderatorId
     type: string
     description: display name of the moderator who added the term
     value: 161545467

--- a/streamerbot/3.api/2.triggers/twitch/moderation/permitted-terms-deleted.md
+++ b/streamerbot/3.api/2.triggers/twitch/moderation/permitted-terms-deleted.md
@@ -7,15 +7,15 @@ variables:
     type: datetime
     description: datetime of the deletion
     value: 28.06.2024 20:13:20
-  - name: moderator.userName
+  - name: moderatorUsername
     type: string
     description: display name of the moderator who deleted the term
     value: Lyfesaver74
-  - name: moderator.login
+  - name: moderatorDisplayName
     type: string
     description: login name of the moderator who deleted the term
     value: lyfesaver74
-  - name: moderator.id
+  - name: moderatorId
     type: string
     description: display name of the moderator who deleted the term
     value: 161545467


### PR DESCRIPTION
Fixed the given variable names for `Blocked Terms Added`, `Blocked Terms Deleted`, `Permitted Terms Added`, `Permitted Terms Deleted`
Changed `moderator.userName` -> `moderatorUsername`
Changed `moderator.login` -> `moderatorDisplayName`
Changed `moderator.id` -> `moderatorId`
Verified correctness of new names through self-tests in StreamerBot.

Implements #308