### PR TITLE
Clarify/fix line numbering conventions in Read from File subactions

### DIFF
--- a/streamerbot/3.api/1.sub-actions/core/file-io/read-lines-from-file.md
+++ b/streamerbot/3.api/1.sub-actions/core/file-io/read-lines-from-file.md
@@ -28,7 +28,7 @@ variables:
     value: 12
   - name: 'line#'
     description: |
-      Each line of output parsed from the file parsed to its own variable
+      Each line of output parsed from the file parsed to its own variable, numbered from 0
 
       e.g. `%line0%`{lang=cs}, `%line1%`{lang=cs}, `%line2%`{lang=cs}, and so on...
     value: 'Hello, world!'

--- a/streamerbot/3.api/1.sub-actions/core/file-io/read-random-line-from-file.md
+++ b/streamerbot/3.api/1.sub-actions/core/file-io/read-random-line-from-file.md
@@ -28,10 +28,17 @@ parameters:
 variables:
   - name: 'randomLine#'
     description: |
-      Each random line extracted based on the `Count` you configured
+      Each random line extracted based on the `Count` you configured. The line counter suffix is omitted from the first line read.
 
-      e.g. `%randomLine0%`{lang=cs}, `%randomLine1%`{lang=cs}, `%randomLine2%`{lang=cs}, and so on...
+      e.g. `%randomLine%`{lang=cs}, `%randomLine1%`{lang=cs}, `%randomLine2%`{lang=cs}, and so on...
     value: 'Hello, world!'
+  - name: 'randomLineNumber#'
+    type: int
+    description: |
+      The line number (numbered from 0) of each random line read. The line counter suffix is omitted from the first line number.
+
+      e.g. `%randomLineNumber%`{lang=cs}, `%randomLineNumber1%`{lang=cs}, `%randomLineNumber2%`{lang=cs}, and so on...
+    value: 3
   - name: fileFound
     type: bool
     description: |

--- a/streamerbot/3.api/1.sub-actions/core/file-io/read-specific-line-from-file.md
+++ b/streamerbot/3.api/1.sub-actions/core/file-io/read-specific-line-from-file.md
@@ -24,7 +24,7 @@ parameters:
   - name: Line Number
     type: Number
     default: 1
-    description: The line to extract from the file
+    description: The line to extract from the file, numbered from 1
 variables:
   - name: 'line'
     description: |


### PR DESCRIPTION
Docs were unclear whether file line numbers start from 0 or 1.  Answer: yes.
Random line variable indices omit the trailing 0