### PR TITLE
Add Guest Star classes found in changelog v0.1.21

### DIFF
--- a/streamerbot/3.api/3.csharp/_classes/GuestSession.md
+++ b/streamerbot/3.api/3.csharp/_classes/GuestSession.md
@@ -1,0 +1,7 @@
+```csharp
+public class GuestSession
+{
+    public string Id { get; set; }
+    public List<GuestStar> Guests { get; set; }
+}
+```

--- a/streamerbot/3.api/3.csharp/_classes/GuestStar.md
+++ b/streamerbot/3.api/3.csharp/_classes/GuestStar.md
@@ -1,0 +1,14 @@
+```csharp
+public class GuestStar
+{
+    public string SlotId { get; set; }
+    public bool IsLive { get; set; }
+    public string UserId { get; set; }
+    public string UserName { get; set; }
+    public string UserLogin { get; set; }
+    public int Volume { get; set; }
+    public DateTime AssignedAt { get; set; }
+    public MediaSettings AudioSettings { get; set; }
+    public MediaSettings VideoSettings { get; set; }
+}
+```

--- a/streamerbot/3.api/3.csharp/_classes/GuestStarInvite.md
+++ b/streamerbot/3.api/3.csharp/_classes/GuestStarInvite.md
@@ -1,0 +1,12 @@
+```csharp
+public class GuestStarInvite
+{
+    public string UserId { get; set; }
+    public DateTime InvitedAt { get; set; }
+    public string Status { get; set; }
+    public bool IsVideoEnabled { get; set; }
+    public bool IsAudioEnabled { get; set; }
+    public bool IsVideoAvailable { get; set; }
+    public bool IsAudioAvailable { get; set; }
+}
+```

--- a/streamerbot/3.api/3.csharp/_classes/GuestStarSettings.md
+++ b/streamerbot/3.api/3.csharp/_classes/GuestStarSettings.md
@@ -1,0 +1,10 @@
+```csharp
+public class GuestStarSettings
+{
+    public bool IsModeratorSendLiveEnabled { get; set; }
+    public int SlotCount { get; set; }
+    public bool IsBrowserSourceAudioEnabled { get; set; }
+    public string GroupLayout { get; set; }
+    public string BrowserSourceToken { get; set; }
+}
+```

--- a/streamerbot/3.api/3.csharp/_classes/MediaSettings.md
+++ b/streamerbot/3.api/3.csharp/_classes/MediaSettings.md
@@ -1,0 +1,8 @@
+```csharp
+public class MediaSettings
+{
+    public bool IsHostEnabled { get; set; }
+    public bool IsGuestEnabled { get; set; }
+    public bool IsAvailable { get; set; }
+}
+```


### PR DESCRIPTION
Guest Star classes referenced within the [api/csharp/twitch/guest-star](https://docs.streamer.bot/api/csharp/twitch/guest-star) methods were missing.  The class properties were taken directly from the referenced [changelog](https://docs.streamer.bot/changelogs/v0.1.21#twitch-guest-star).