### PR TITLE
Update 0.configuration.md

### DIFF
--- a/streamerbot/3.api/5.http/0.guide/0.configuration.md
+++ b/streamerbot/3.api/5.http/0.guide/0.configuration.md
@@ -33,7 +33,7 @@ parameters:
     description: |
       A list of URL path mappings to local directories or files to serve via HTTP.
 
-      - `Path`: The URL path to map to (e.g., `/files`)
+      - `Path`: The URL path to map to (e.g., `files`)
       - `Folder`: The local directory or file to serve (e.g., `C:\path\to\directory`)
 ---
 ::


### PR DESCRIPTION
The HTTP Server does not need the leading / character on the mapped path. It is implied and added automatically on the server side.