### PR TITLE
fix links to quotes example

### DIFF
--- a/streamerbot/2.guide/08.settings/quotes.md
+++ b/streamerbot/2.guide/08.settings/quotes.md
@@ -3,7 +3,7 @@ title: Quotes
 description: Streamer.bot has a built in quote system. It allows to add, display and delete quotes. Adding a quote automatically assigns an ID and saves a timestamp, the quoting user, the platform as well as the current category (like "Just Chatting").
 ---
 
-::warning{to=examples/quotes-commands}
+::warning{to=/examples/quotes-commands}
 This page documents the old quote system prior to Streamer.bot 1.0.0<br/>
 :icon{name=i-mdi-navigation} See `Quotes Commands for v1.0.0+` for guidance on using the new quote sub-actions
 ::

--- a/streamerbot/3.api/1.sub-actions/core/quotes/add-quote.md
+++ b/streamerbot/3.api/1.sub-actions/core/quotes/add-quote.md
@@ -51,4 +51,4 @@ This Sub-Action will set the quote user to the user who called the action<br/>
 Setting the quote user to a different user than the caller is only supported via the C# Method
 ::
 
-:read-more{to=examples/quotes-commands}
+:read-more{to=/examples/quotes-commands}

--- a/streamerbot/3.api/1.sub-actions/core/quotes/delete-quote.md
+++ b/streamerbot/3.api/1.sub-actions/core/quotes/delete-quote.md
@@ -28,4 +28,4 @@ Deleting a quote does not change the Quote ID of following quotes<br/>
 You can Re-Index quotes manually under `Services > Quotes` by right-clicking and choosing `Re-index` from the context menu.  **This operation can not be undone**
 ::
 
-:read-more{to=examples/quotes-commands}
+:read-more{to=/examples/quotes-commands}

--- a/streamerbot/3.api/1.sub-actions/core/quotes/get-quote-count.md
+++ b/streamerbot/3.api/1.sub-actions/core/quotes/get-quote-count.md
@@ -14,4 +14,4 @@ csharpMethods:
 The Count returned by this Sub-Action is not necessarily the same as the last Quote ID, on account of deleted quotes.
 ::
 
-:read-more{to=examples/quotes-commands}
+:read-more{to=/examples/quotes-commands}

--- a/streamerbot/3.api/1.sub-actions/core/quotes/get-quote.md
+++ b/streamerbot/3.api/1.sub-actions/core/quotes/get-quote.md
@@ -52,4 +52,4 @@ csharpMethods:
   - GetQuote
 ---
 
-:read-more{to=examples/quotes-commands}
+:read-more{to=/examples/quotes-commands}


### PR DESCRIPTION
i made a mistake, and these links turned out relative when they shouldn't have been