### PR TITLE
add import to global set and get subaction params

### DIFF
--- a/streamerbot/3.api/1.sub-actions/core/globals/global-get.md
+++ b/streamerbot/3.api/1.sub-actions/core/globals/global-get.md
@@ -3,7 +3,9 @@ title: Get Global Variable
 description: Fetch the value of a global variable and populate a local argument
 parameters:
   - name: Source
+    import: core/GlobalVariableSource
   - name: Persisted
+    import: core/GlobalVariablePersisted
   - name: Variable Name
     type: Text
     required: true

--- a/streamerbot/3.api/1.sub-actions/core/globals/global-set.md
+++ b/streamerbot/3.api/1.sub-actions/core/globals/global-set.md
@@ -3,7 +3,9 @@ title: Set Global Variable
 description: Create or update the value of a global variable
 parameters:
   - name: Destination
+    import: core/GlobalVariableDestination
   - name: Persisted
+    import: core/GlobalVariablePersisted
   - name: Variable Name
     type: Text
     required: true


### PR DESCRIPTION
the only examples of imports are currently in the csharp section, and those imports are adding some data from imported params like default values, but not adding the descriptions from the imported parameter.  the parameter markdown files that the files changed in this PR are attempting to import have the descriptions as `md` body rather than `yaml` frontmatter, which *did* import the descriptions correctly a few days ago when it was auto importing based on matching `-name` values, so i'm hoping it works the same with the explicit import.
please advise if it just works entirely differently now