### PR TITLE
add message var to chat message deleted trigger

### DIFF
--- a/streamerbot/3.api/2.triggers/twitch/moderation/chat-message-deleted.md
+++ b/streamerbot/3.api/2.triggers/twitch/moderation/chat-message-deleted.md
@@ -7,6 +7,9 @@ variables:
   - name: targetMessageId
     type: string
     description: The unique identifier for the message that has been deleted
+  - name: message
+    type: string
+    description: Text content of the deleted message
 commonVariables:
   - TwitchBroadcaster
   - TwitchUser


### PR DESCRIPTION
trigger does not contain `rawInput` or most chat message vars, but does contain `message`