### PR TITLE
Update create-clip.md for 1.0.3 with Title and Duration parameters

### DIFF
--- a/streamerbot/3.api/1.sub-actions/twitch/channel/create-clip.md
+++ b/streamerbot/3.api/1.sub-actions/twitch/channel/create-clip.md
@@ -1,6 +1,15 @@
 ---
 title: Create Clip
-description: Create a 30-second Twitch Clip
+description: Create a Twitch Clip
+parameters:
+  - name: Clip Title
+    type: String
+    required: false
+    description: If blank, will match the stream title at the time of creation.
+  - name: Duration
+    type: Int
+    required: false
+    description: In seconds. Value must be between 5 and 60 (inclusive). If blank, defaults to 30s.
 variables:
   - name: createClipSuccess
     type: bool
@@ -21,11 +30,3 @@ variables:
 csharpMethods:
   - CreateClip
 ---
-
-::warning
-**Twitch API restrictions**
-- The generated clip will always be 30 seconds in length
-- The clip title will match your stream title at the time of creation
-
-  To make your own changes to the clip duration and/or title, you can manually edit the clip later.
-::


### PR DESCRIPTION
Adds the Title and Duration as parameters on the Create Clip page and removes the `Twitch API restrictions` warning that is no longer relevant.