### PR TITLE
update links to stream-apps guide section

### DIFF
--- a/streamerbot/1.get-started/2.setup.md
+++ b/streamerbot/1.get-started/2.setup.md
@@ -209,8 +209,8 @@ This guide assumes you are running **OBS Studio** version `28.0.0` or later
     If you are having trouble connecting, double-check the **Host, Port, Password, and Version** to ensure it matches your OBS Studio instance.
     ::
 
-    ::read-more{to=/guide/broadcasters/obs-studio}
-    Explore the full [OBS Studio Configuration Guide](/guide/broadcasters/obs-studio) to learn more about all available options.
+    ::read-more{to=/guide/stream-apps/obs-studio}
+    Explore the full [OBS Studio Configuration Guide](/guide/stream-apps/obs-studio) to learn more about all available options.
     ::
 
 ---
@@ -243,8 +243,8 @@ Set up Streamer.bot to remotely control your Streamlabs Desktop instance
 
     To add a new connection, :kbd{value="Right-Click"} anywhere in the panel area and select `Add`
 
-    ::read-more{to=/guide/broadcasters/streamlabs-desktop}
-    Explore the full [Streamlabs Desktop Configuration Guide](/guide/broadcasters/streamlabs-desktop) to learn more about all available options.
+    ::read-more{to=/guide/stream-apps/streamlabs-desktop}
+    Explore the full [Streamlabs Desktop Configuration Guide](/guide/stream-apps/streamlabs-desktop) to learn more about all available options.
     ::
 
 ---
@@ -278,4 +278,4 @@ Set up Streamer.bot to remotely control your Meld Studio instance
     - Click `OK` when you have finished configuration
     - :kbd{value="Right-Click"} the new instance and select `Connect` to force an immediate connection attempt
 
-    :read-more{to=/guide/broadcasters/meld-studio}
+    :read-more{to=/guide/stream-apps/meld-studio}

--- a/streamerbot/3.api/.parameters/meld-studio/connection.md
+++ b/streamerbot/3.api/.parameters/meld-studio/connection.md
@@ -7,4 +7,4 @@ options:
     description: All configured Meld Studio connections
 ---
 
-Select the configured [Meld Studio Connection](/guide/broadcasters/meld-studio) to connect to
+Select the configured [Meld Studio Connection](/guide/stream-apps/meld-studio) to connect to

--- a/streamerbot/3.api/.parameters/obs-studio/connection.md
+++ b/streamerbot/3.api/.parameters/obs-studio/connection.md
@@ -10,4 +10,4 @@ options:
     description: All configured OBS Studio connections
 ---
 
-Select the configured [OBS Studio Connection](/guide/broadcasters/obs-studio) to connect to
+Select the configured [OBS Studio Connection](/guide/stream-apps/obs-studio) to connect to

--- a/streamerbot/3.api/.parameters/streamlabs-desktop/connection.md
+++ b/streamerbot/3.api/.parameters/streamlabs-desktop/connection.md
@@ -4,4 +4,4 @@ type: Select
 required: true
 ---
 
-Select the configured [Streamlabs Desktop Connection](/guide/broadcasters/streamlabs-desktop) to connect to
+Select the configured [Streamlabs Desktop Connection](/guide/stream-apps/streamlabs-desktop) to connect to

--- a/streamerbot/3.api/1.sub-actions/obs-studio/raw.md
+++ b/streamerbot/3.api/1.sub-actions/obs-studio/raw.md
@@ -9,7 +9,7 @@ csharpMethods:
   - ObsSendRaw
 ---
 
-:read-more{to=/guide/broadcasters/obs-studio}
+:read-more{to=/guide/stream-apps/obs-studio}
 
 ::tip{to="https://obs-raw.streamer.bot"}
 You can use the [OBS Raw Generator](https://obs-raw.streamer.bot) to generate raw requests in Raw JSON or C# Code format


### PR DESCRIPTION
links were to 
https://docs.streamer.bot/guide/broadcasters/obs-studio
which is now at 
https://docs.streamer.bot/guide/stream-apps/obs-studio