### PR TITLE
Fix GetGlobalVar usage

### DIFF
--- a/streamerbot/3.api/3.csharp/0.guide/1.variables.md
+++ b/streamerbot/3.api/3.csharp/0.guide/1.variables.md
@@ -147,7 +147,7 @@ string jsonSaveString = JsonConvert.SerializeObject(testList);
 CPH.SetGlobalVar("savingClass", jsonSaveString, true);
 
 //... Deserializing saved JSON string
-string savedString = CPH.GetGlobalVar("savingClass", true);
+string savedString = CPH.GetGlobalVar<string>("savingClass", true);
 List<TestClass> savedList = JsonConvert.DeserializeObject<List<TestClass>>(savedString);
 ```
 


### PR DESCRIPTION
Explicitly provide `<string>` to CPH.GetGlobalVar for compilation.