### PR TITLE
Note requirements for Speak speechFile

### DIFF
--- a/streamerbot/3.api/1.sub-actions/speakerbot/speak.md
+++ b/streamerbot/3.api/1.sub-actions/speakerbot/speak.md
@@ -7,7 +7,10 @@ variables:
     type: bool
     value: true
   - name: speechFile
-    description: The file containing the speech audio, or `null` if it doesn't exist
+    description: |
+      The file containing the speech audio, or `null` if it doesn't exist.
+    
+      **Note**: The "Save TTS audio to file" option must be enabled in the Speaker.bot settings, and either the "Silent" or "Delay" parameters.
     type: string
   - name: duration
     description: The duration of the speech, when the delay option is used


### PR DESCRIPTION
Added note about enabling 'Save TTS audio to file' option and parameters. I put the note on the speechFile variable, rather than in the Parameters, because the variable is affected by 2 different params, plus the speakerbot setting.