### PR TITLE
add missing variables for twitch rewards

### DIFF
--- a/streamerbot/3.api/1.sub-actions/twitch/rewards/get-reward-info.md
+++ b/streamerbot/3.api/1.sub-actions/twitch/rewards/get-reward-info.md
@@ -1,21 +1,59 @@
-# Get Reward Info
-Get the info from a reward.
-
-## Parameters
-### `Reward`
-Choose the reward where you want to get the info from.
-
-## Variables
-:variables-description
-Name | Description
-----:|:------------
-`rewardId` | String identifier for this reward
-`rewardTitle` | The title of the reward
-`rewardBackgroundColor` | The background color of the reward
-`rewardEnabled` | If the reward is enabled
-`rewardPrompt` | The verbiage shown on the channel point description
-`rewardSkipReuqestQueue` | If there is a skip request in the queue
-`rewardCost` | The cost of the reward
-
-## C# Usage
-:csharp-method{name=TwitchGetRewards}
+---
+title: Get Reward Info
+description: Get the info from a reward.
+parameters:
+  - name: Reward
+    type: Select
+    required: true
+    description: Choose the reward where you want to get the info from.
+variables:
+  - name: rewardId
+    type: string
+    description: The unique identifier for the reward
+    value: 44e86f71-8ace-4739-a123-3ff095489343
+  - name: rewardCost
+    type: number
+    description: The cost of the reward
+    value: 200
+  - name: rewardTitle
+    type: string
+    description: The name of the reward
+    value: My Reward
+  - name: rewardBackgroundColor
+    type: string
+    description: The background color of the reward, in hex format
+    value: "#FFFF00"
+  - name: rewardEnabled
+    type: bool
+    description: If the reward is enabled
+    value: True
+  - name: rewardPaused
+    type: bool
+    description: If the reward is paused
+    value: False
+  - name: rewardPrompt
+    type: string
+    description: The description of the reward
+    value: My Reward description
+  - name: rewardSkipRequestQueue
+    type: bool
+    description: Whether or not the Reward is auto completed when redeemed
+    value: False
+  - name: rewardMaxPerStream
+    type: number
+    description: How many total redemptions can be done per stream, 0 means no limit
+    value: 0
+  - name: rewardMaxPerUserPerStream
+    type: number
+    description: How many redemptions each user can make per stream, 0 means no limit
+    value: 0
+  - name: rewardGlobalCooldown
+    type: number
+    description: The global cooldown of the Reward in seconds
+    value: 0
+  - name: rewardIsOurs
+    type: bool
+    description: If the reward is owned by Streamer.bot and can be updated by sub-actions
+csharpMethods:
+  - TwitchGetRewards
+---

--- a/streamerbot/3.api/2.triggers/twitch/channel-reward/reward-redemption.md
+++ b/streamerbot/3.api/2.triggers/twitch/channel-reward/reward-redemption.md
@@ -40,6 +40,34 @@ variables:
     type: string
     description: The text entered by the user (if enabled)
     value: https://streamer\.bot/Test Escaped Text \$\$\$
+  - name: rawInputUrlEncoded
+    type: string
+    description: The raw user input for the reward redemption, URL encoded
+    value: "This%20is%20my%20reward%20input"
+  - name: skipsQueue
+    type: bool
+    description: Whether or not the Reward is auto completed when redeemed
+    value: false
+  - name: requiresUserInput
+    type: bool
+    description: Whether or not the Reward requires user input
+    value: true
+  - name: maxPerStream
+    type: number
+    description: How many total redemptions can be done per stream, 0 means no limit
+    value: 0
+  - name: maxPerUserPerStream
+    type: number
+    description: How many redemptions each user can make per stream, 0 means no limit
+    value: 0
+  - name: globalCooldown
+    type: number
+    description: The global cooldown of the Reward in seconds
+    value: 0
+  - name: backgroundColor
+    type: string
+    description: The background color of the reward that was redeemed, in hex format
+    value: "#FFFF00"
 commonVariables:
   - TwitchBroadcaster
   - TwitchUser


### PR DESCRIPTION
added variables for
- reward redemption trigger
- get reward info sub-action
used screenshots for argument data from https://discord.com/channels/834650675224248362/1518730925838434436/1518757406341992629